### PR TITLE
Database Version Tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ db/database.sqlite
 .idea
 .vscode
 db/db_inits/tmp.sql
+/db/db-version.txt


### PR DESCRIPTION
Write the latest executed database initialization process version into db/db-version.txt (auto create if not existing after the initialization process), and omit initialization processes whose versions are smaller than it. In this way, initialization processes that are already performed on the database will not be performed again.
The file db/db-version.txt is also added into .gitignore.
Also corrected places in db.js where console.log is used for outputing errors instead of console.error.